### PR TITLE
Add a new Docker image with YugabyteDB tools only

### DIFF
--- a/.docker/yugabyte-tools/Dockerfile
+++ b/.docker/yugabyte-tools/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.14
+
+ARG GID=1060
+ARG GROUPNAME=yugabyte
+ARG UID=1060
+ARG USERNAME=yugabyte
+
+RUN addgroup -g ${GID} ${GROUPNAME} \
+    && adduser -u ${UID} -G ${GROUPNAME} -D -H ${USERNAME}
+COPY --chown=${USERNAME}:${GROUPNAME} tools /home/${USERNAME}
+RUN mkdir -p /home/${USERNAME}/www \
+    && chown ${USERNAME}:${GROUPNAME} /home/${USERNAME}/www \
+    && ln -s /home/${USERNAME}/bin/cqlsh /usr/bin/cqlsh \
+    && ln -s /home/${USERNAME}/bin/yb-admin /usr/bin/yb-admin \
+    && ln -s /home/${USERNAME}/bin/yb-bulk_load /usr/bin/yb-bulk_load \
+    && ln -s /home/${USERNAME}/bin/yb-ctl /usr/bin/yb-ctl \
+    && ln -s /home/${USERNAME}/bin/yb-ts-cli /usr/bin/yb-ts-cli \
+    && ln -s /home/${USERNAME}/bin/ysql_bench /usr/bin/ysql_bench \
+    && ln -s /home/${USERNAME}/bin/ysql_dump /usr/bin/ysql_dump \
+    && ln -s /home/${USERNAME}/bin/ysql_dumpall /usr/bin/ysql_dumpall \
+    && ln -s /home/${USERNAME}/bin/ysqlsh /usr/bin/ysqlsh
+
+USER ${USERNAME}

--- a/.docker/yugabyte-tools/prepare-tools.sh
+++ b/.docker/yugabyte-tools/prepare-tools.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -euo
+
+patchelfpath=$(find /home -name patchelf)
+if [ -z "${patchelfpath}" ]; then
+    echo "ERROR: doesn't look like a YugabyteDB image"
+    exit 1
+fi
+
+source_root=$(dirname $(dirname ${patchelfpath}))
+TARGET_ROOT=${TARGET_ROOT:-/tools}
+
+# copy YB binaries:
+binaries=("cqlsh" "yb-admin" "yb-bulk_load" "yb-ctl" "yb-ts-cli")
+for f in "${binaries[@]}"; do
+  mkdir -p "${TARGET_ROOT}/bin"
+  cp -v "${source_root}/bin/${f}" "${TARGET_ROOT}/bin/${f}"
+done
+
+# copy Postgres binaries:
+binaries=("ysql_bench" "ysql_dump" "ysql_dumpall" "ysqlsh")
+for f in "${binaries[@]}"; do
+  mkdir -p "${TARGET_ROOT}/postgres/bin"
+  cp -v "${source_root}/postgres/bin/${f}" "${TARGET_ROOT}/postgres/bin/${f}"
+done
+
+# copy YB libs:
+for f in $(find ${source_root}/lib -name '*.so*'); do
+  relative=$(echo $f | sed 's!'${source_root}'!!')
+  full_target="${TARGET_ROOT}${relative}"
+  mkdir -p $(dirname ${full_target})
+  cp -v ${f} ${full_target}
+done
+
+# copy Postgres libs:
+for f in $(find ${source_root}/postgres/lib -name 'libpq.so*'); do
+  relative=$(echo $f | sed 's!'${source_root}'!!')
+  full_target="${TARGET_ROOT}${relative}"
+  mkdir -p $(dirname ${full_target})
+  cp -v ${f} ${full_target}
+done
+
+# copy Linux Brew libs:
+for f in $(find ${source_root}/linuxbrew -name '*.so*'); do
+  relative=$(echo $f | sed 's!'${source_root}'!!')
+  full_target="${TARGET_ROOT}${relative}"
+  mkdir -p $(dirname ${full_target})
+  cp -v ${f} ${full_target}
+done

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.docker/yugabyte-tools/tools/**
+!.docker/yugabyte-tools/tools/.gitkeep

--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ docker build -t local/yugabyte:2.9.1.0-b140 -f Dockerfile.uid .
 cd -
 ```
 
+## Build the tools only image
+
+```sh
+cd .docker/yugabyte-tools/
+export DOCKER_IMAGE="yugabytedb/yugabyte"
+export DOCKER_TAG="2.9.1.0-b140"
+docker run --rm \
+    -v $(pwd)/prepare-tools.sh:/tmp/prepare-tools.sh \
+    -v $(pwd)/tools:/tools \
+    --entrypoint /tmp/prepare-tools.sh \
+    -ti ${DOCKER_IMAGE}:${DOCKER_TAG}
+docker build --no-cache -t local/yugabyte-tools:${DOCKER_TAG} .
+cd -
+```
+
 ## YugabyteDB dashboard
 
 YugabyteDB dashboard can be accessed on port `7000`. Usually `http://localhost:7000`.


### PR DESCRIPTION
Assuming a cluster launched using instructions from the readme file:

```sh
docker run --rm \
  --net=yb-dbnet \
  -ti local/yugabyte-tools:2.9.1.0-b140 \
  yb-admin -master_addresses yb-master-n1:7100,yb-master-n2:7100,yb-master-n3:7100 list_all_masters
```

```
Master UUID                      	RPC Host/Port        	State    	Role
2da0c4a5c8454e0094d84af84723272a 	yb-master-n1:7100    	ALIVE    	LEADER
6ddfa71d51884e09bcf4ba27e46db0f8 	yb-master-n2:7100    	ALIVE    	FOLLOWER
8ebce54a4cf7423ab3f4e84f69672fa1 	yb-master-n3:7100    	ALIVE    	FOLLOWER
```

```sh
docker run --rm \
  --net=yb-dbnet \
  -ti local/yugabyte-tools:2.9.1.0-b140 \
  yb-admin -master_addresses yb-master-n1:7100,yb-master-n2:7100,yb-master-n3:7100 list_all_tablet_servers
```

```
Tablet Server UUID               RPC Host/Port Heartbeat delay Status   Reads/s  Writes/s Uptime   SST total size  SST uncomp size SST #files      Memory
802bec086b4e4a0787887298f328ce1a yb-tserver-shared-1:9100 0.42s           ALIVE    0.00     0.00     405      0 B             0 B             0               41.94 MB
bb7ef7acb635485a8539abad532e6139 yb-tserver-shared-3:9100 0.42s           ALIVE    0.00     0.00     410      0 B             0 B             0               40.89 MB
7c31a20f0cef43afa26f10f900e206ba yb-tserver-tenant1-3:9100 0.42s           ALIVE    0.00     0.00     409      0 B             0 B             0               45.09 MB
3a754e3198154d0d964a8013714440bf yb-tserver-tenant1-1:9100 0.42s           ALIVE    0.00     0.00     409      0 B             0 B             0               45.09 MB
4c0f6773ec0b4a9dbebbf2b11077a7f3 yb-tserver-shared-2:9100 0.42s           ALIVE    0.00     0.00     409      0 B             0 B             0               46.14 MB
ee83d44156a34579a9905a37fbba48c2 yb-tserver-tenant1-2:9100 0.42s           ALIVE    0.00     0.00     409      0 B             0 B             0               45.09 MB
```

And so on.